### PR TITLE
kneed 0.8.6

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-upload_channels:
-  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,16 +1,17 @@
 {% set name = "kneed" %}
-{% set version = "0.8.5" %}
+{% set version = "0.8.6" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: a4847ac4f1d04852fea278d5de7aa8bfdc3beb7fbca4a182fec0f0efee43f4b1
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 65b22727c623661701f15edf057f2e6c73e2b1ad4e68cd9ca4291675c318b5ef
 
 build:
   number: 0
+  skip: true  # [py<39]
   script: {{ PYTHON }} -m pip install . --no-build-isolation --no-deps -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,8 @@ requirements:
     - python
     - numpy >=1.14.2
     - scipy >=1.0.0
+  run_constrained:
+    - matplotlib-base >=2.2.5    
 test:
   imports:
     - kneed


### PR DESCRIPTION
kneed 0.8.6

**Destination channel:** defaults

### Links

- [PKG-12668](https://anaconda.atlassian.net/browse/PKG-12668)
- [Upstream repository](https://github.com/arvkevi/kneed)
- [PyPI 0.8.6](https://pypi.org/project/kneed/0.8.6/)
- [Upstream diff 0.8.5...0.8.6 (PyPI)](https://pypi.org/project/kneed/#history)

### Explanation of changes:

- Update from 0.8.5 to 0.8.6 (latest upstream, released 2026-03-20). Ticket PKG-12668 was filed against 0.8.5, but Tyler Ferguson accepted it based on the 0.8.6 release as evidence of active upstream maintenance — shipping 0.8.6 matches that rationale and avoids landing a stale version on day 1.

[PKG-12668]: https://anaconda.atlassian.net/browse/PKG-12668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ